### PR TITLE
Fixed post card link url

### DIFF
--- a/components/posts/posts.vue
+++ b/components/posts/posts.vue
@@ -5,7 +5,7 @@
       :key="index"
     >
       <nuxt-link
-        :to="`${postType}/${post.slug}`"
+        :to="`/${postType}/${post.slug}`"
         class="card card--clickable"
       >
         <template v-if="postType === 'projects'">


### PR DESCRIPTION
This fixes post card links navigating to the wrong route on the generated site.

### To reproduce:

- Go directly to, or refresh [https://ntn-boilerplate.netlify.app/blog](https://ntn-boilerplate.netlify.app/blog) or [https://ntn-boilerplate.netlify.app/projects](https://ntn-boilerplate.netlify.app/projects).
- Click on a post card.
- Navigates to `/blog/blog/...` or `projects/projects/...` causing 404.